### PR TITLE
wrong example below key: function(err, val){..}

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ callback(err, value)
 getRange(keyChain, fromIndex,[ toIndex,] callback)
 ```
 This function assumes that the value at ```keyChain``` is an Array or Object.
-Capture all values starting at ```fromIndex``` and finishing at ```toIndex``
+Capture all values starting at ```fromIndex``` and finishing at ```toIndex```
 but **not including** ```toIndex```. If ```toIndex`` is not specified, all
 values from ```fromIndex``` until the end of the Array or Object will be
 included. The callback is in form:


### PR DESCRIPTION
the callback of `.get()` should have two params (see line 300 and 323); sorry for committing two requsts
